### PR TITLE
Add two additional build dependencies

### DIFF
--- a/porting/index.md
+++ b/porting/index.md
@@ -22,7 +22,7 @@ sudo apt install git gnupg flex bison gperf build-essential \
   libx11-dev:i386 libreadline6-dev:i386 libgl1-mesa-glx:i386 \
   libgl1-mesa-dev g++-multilib mingw-w64-i686-dev tofrodos \
   python-markdown libxml2-utils xsltproc zlib1g-dev:i386 schedtool \
-  repo
+  repo liblz4-tool bc
 ```
 
 **//TODO: Add instructions for installing build tools for other distros as well**


### PR DESCRIPTION
This packages are needed to compile hybris-boot and the kernel on debian stretch. Tested with sources for the Sony Xperia Z.