### PR TITLE
Add section about lxc-android

### DIFF
--- a/porting/debug-build/debug-android-userspace.rst
+++ b/porting/debug-build/debug-android-userspace.rst
@@ -4,6 +4,27 @@ Debugging the Android userspace
 
 Debugging the Android userspace
 
+lxc-android
+-----------
+lxc-android is the container in which the Android userspace is running. You can check that it is started with the following command::
+
+    systemctl status lxc@android
+
+LXC needs some kernel config to make sure it runs correctly. Check that you have all the needed options by running the following command on the device::
+
+    lxc-checkconfig
+
+All option except `User namespace` need to be the green word `enabled`. If one of the options is a yellow `missing` or a red `required`, then you need to change the kernel config, rebuild hybrid-boot and check the status again.
+
+.. note::
+
+    I was getting the following error, which I didn't understand:
+    ``lxc-start: utils.c: mkdir_p: 254 Invalid argument - failed to create directory '/sys/fs/cgroup/net_cls//lxc/android'``
+    It appears like LXC is expecting some functionality that doesn't work yet in Linux 3.4. Counter-intuitively I had to disable the following functionalities in the defconfig to make it work::
+
+        CONFIG_NET_CLS_CGROUP=n
+        CONFIG_NETPRIO_CGROUP=n
+
 Logcat
 ------
 


### PR DESCRIPTION
I added a section about checking the status of lxc-android and kernel config needed for lxc-android. This was based on what I read in the support channel. I also added a note about a specific error I got, but I don't know whether this is appropriate for the docs.