### PR TITLE
Clarify: Modify the kernel configuration

### DIFF
--- a/porting/build-sources.rst
+++ b/porting/build-sources.rst
@@ -55,7 +55,7 @@ Modify the kernel configuration
 
 Halium uses systemd as the init system. This requires various specific kernel configurations.
 
-To check the kernel config we use `mer-kernel-check <https://github.com/mer-hybris/mer-kernel-check>`_ utility provided by mer-hybris::
+To check which config options needs to be adjusted we use `mer-kernel-check <https://github.com/mer-hybris/mer-kernel-check>`_ utility provided by mer-hybris::
 
    git clone https://github.com/mer-hybris/mer-kernel-check
    cd mer-kernel-check

--- a/porting/build-sources.rst
+++ b/porting/build-sources.rst
@@ -53,9 +53,9 @@ Breakfast will attempt to find your device, set up all of the environment variab
 Modify the kernel configuration
 -------------------------------
 
-Halium uses the systemd as the init system which requires various kernel config options to be enabled.
+Halium uses systemd as the init system. This requires various specific kernel configurations.
 
-To check which config options needs to be enabled we use `mer-kernel-check <https://github.com/mer-hybris/mer-kernel-check>`_ utility provided by mer-hybris::
+To check the kernel config we use `mer-kernel-check <https://github.com/mer-hybris/mer-kernel-check>`_ utility provided by mer-hybris::
 
    git clone https://github.com/mer-hybris/mer-kernel-check
    cd mer-kernel-check


### PR DESCRIPTION
removed extraneous "the", simplified the language and clarified that we're not only "enabling"