### PR TITLE
Document confusing/misleading kernel configuration syntax

### DIFF
--- a/porting/build-sources.rst
+++ b/porting/build-sources.rst
@@ -63,8 +63,17 @@ To check which config options needs to be adjusted we use `mer-kernel-check <htt
 
 If you don't know the path to your kernel config run ``grep "TARGET_KERNEL_CONFIG" device/<VENDOR>/<CODENAME>/BoardConfig.mk``. It should be in ``arch/arm/configs/<CONFIG>`` or ``arch/arm64/configs/<CONFIG>`` depending on the architecture of your device.
 
+.. warning::
+		Make sure that your configuration changes are not overridden by later lines in the config file.
+		
+		Also be aware that ``# CONFIG_IKCONFIG_PROC is not set`` *may* look like a harmless comment, `but it actually unsets`__ ``CONFIG_IKCONFIG_PROC`` if it is set (e.g. by an edit you made earlier in the file).
+		
+		.. __: https://www.tldp.org/HOWTO/SCSI-2.4-HOWTO/kconfig.html
+		
+		The build process will warn you if you do override any config entries, e.g. ``arch/arm/configs/<CONFIG>:<LINE NUMBER>:warning: override: reassigning to symbol IKCONFIG_PROC``
+
 .. todo::
-    Mention that the config parameters CONFIG_IKCONFIG and CONFIG_IKCONFIG_PROC need to be set to y, otherwise Halium wont boot (or add them to the check script
+    Mention that the config parameters CONFIG_IKCONFIG and CONFIG_IKCONFIG_PROC need to be set to y, otherwise Halium wont boot (or add them to the check script)
 
 Include your device in fixup-mountpoints
 ----------------------------------------

--- a/porting/build-sources.rst
+++ b/porting/build-sources.rst
@@ -66,9 +66,7 @@ If you don't know the path to your kernel config run ``grep "TARGET_KERNEL_CONFI
 .. warning::
 		Make sure that your configuration changes are not overridden by later lines in the config file.
 		
-		Also be aware that ``# CONFIG_IKCONFIG_PROC is not set`` *may* look like a harmless comment, but it actually unsets ``CONFIG_IKCONFIG_PROC`` if it is set (e.g. by an edit you made earlier in the file); see `Kernel Configuration in the Linux kernel documentation`__.
-		
-		.. __: https://www.tldp.org/HOWTO/SCSI-2.4-HOWTO/kconfig.html
+		Also be aware that ``# CONFIG_IKCONFIG_PROC is not set`` *may* look like a harmless comment, but it actually unsets ``CONFIG_IKCONFIG_PROC`` if it is set (e.g. by an edit you made earlier in the file); see `Kernel Configuration in the Linux kernel documentation <https://www.tldp.org/HOWTO/SCSI-2.4-HOWTO/kconfig.html>`_.
 		
 		The build process will warn you if you do override any config entries, e.g. ``arch/arm/configs/<CONFIG>:<LINE NUMBER>:warning: override: reassigning to symbol IKCONFIG_PROC``
 

--- a/porting/build-sources.rst
+++ b/porting/build-sources.rst
@@ -67,6 +67,7 @@ If you don't know the path to your kernel config run ``grep "TARGET_KERNEL_CONFI
 		Make sure that your configuration changes are not overridden by later lines in the config file.
 		
 		Also be aware that ``# CONFIG_IKCONFIG_PROC is not set`` *may* look like a harmless comment, but it actually unsets ``CONFIG_IKCONFIG_PROC`` if it is set (e.g. by an edit you made earlier in the file); see `Kernel Configuration in the Linux kernel documentation <https://www.tldp.org/HOWTO/SCSI-2.4-HOWTO/kconfig.html>`_.
+                See also `PR #85 on GitHub about this quirk <https://github.com/Halium/docs/pull/85>`_.
 		
 		The build process will warn you if you do override any config entries, e.g. ``arch/arm/configs/<CONFIG>:<LINE NUMBER>:warning: override: reassigning to symbol IKCONFIG_PROC``
 

--- a/porting/build-sources.rst
+++ b/porting/build-sources.rst
@@ -66,7 +66,7 @@ If you don't know the path to your kernel config run ``grep "TARGET_KERNEL_CONFI
 .. warning::
 		Make sure that your configuration changes are not overridden by later lines in the config file.
 		
-		Also be aware that ``# CONFIG_IKCONFIG_PROC is not set`` *may* look like a harmless comment, `but it actually unsets`__ ``CONFIG_IKCONFIG_PROC`` if it is set (e.g. by an edit you made earlier in the file).
+		Also be aware that ``# CONFIG_IKCONFIG_PROC is not set`` *may* look like a harmless comment, but it actually unsets ``CONFIG_IKCONFIG_PROC`` if it is set (e.g. by an edit you made earlier in the file); see `Kernel Configuration in the Linux kernel documentation`__.
 		
 		.. __: https://www.tldp.org/HOWTO/SCSI-2.4-HOWTO/kconfig.html
 		


### PR DESCRIPTION
Hello there.

I'm back again :-)

When I installed the Halium reference rootfs onto my phone, I ended up in the telnet debugging session and the diagnostic log told me that IKCONFIG_PROC wasn't set... which was confusing to me, as I distinctly remembered setting it.

A few hours later of hunting for *just what* is overriding the config setting, digging around in makefiles to try and see what could possibly override it... it turns out that I had a line `# CONFIG_IKCONFIG_PROC is not set` in my `cedric_defconfig` (that I *borrowed* from another source) -- this is not a comment! It actually de-selects/unsets the option!

I think this syntax is misleading/confusing (it looks really innocent as it even has a space after the hash, unlike C preprocessor directives..); hopefully this warning in the docs can save someone some considerable time.

Off-topic for this issue, but the `mer_verify_kernel_config` tool is confused by `defconfig` files with CRLF (Windoze-style) terminators, giving many warnings that look silly (as it effectively says '`y` is allowed, found `y`'). But that tool doesn't have an issues section in the GitHub repository.