### PR TITLE
Add an alternative installation method (JBB's script)

### DIFF
--- a/porting/install-build/reference-rootfs.rst
+++ b/porting/install-build/reference-rootfs.rst
@@ -62,6 +62,15 @@ This will do the following:
 * Convert system.img into the ext4 mountable image from android sparse image.
 * Push the both images to /data partition
 
+Install rootfs and system.img (alternative method)
+--------------------------------------------------
+
+If the method above failed for some reason, you could try the ``halium-install`` script from the `JBB's repository <https://github.com/JBBgameich/halium-install/>`_.
+
+You can use the halium-install script as below, when the device is connected in recovery mode::
+
+   halium-install <path to rootfs tarball> <path to android system.img> halium
+
 Debugging
 ---------
 

--- a/porting/install-build/reference-rootfs.rst
+++ b/porting/install-build/reference-rootfs.rst
@@ -54,7 +54,7 @@ Currently the latest rootfs is available at bshah's personal server: `Link <http
 
 You can use the halium-install script as below, when the device is connected in recovery mode::
 
-   halium-install -p halium <path to rootfs tarball> <path to android system.img>
+   halium-install <path to rootfs tarball> <path to android system.img>
 
 This will do the following:
 
@@ -69,7 +69,7 @@ If the method above failed for some reason, you could try the ``halium-install``
 
 You can use the halium-install script as below, when the device is connected in recovery mode::
 
-   halium-install <path to rootfs tarball> <path to android system.img> halium
+   halium-install -p halium <path to rootfs tarball> <path to android system.img>
 
 Debugging
 ---------

--- a/porting/install-build/reference-rootfs.rst
+++ b/porting/install-build/reference-rootfs.rst
@@ -54,7 +54,7 @@ Currently the latest rootfs is available at bshah's personal server: `Link <http
 
 You can use the halium-install script as below, when the device is connected in recovery mode::
 
-   halium-install <path to rootfs tarball> <path to android system.img>
+   halium-install -p halium <path to rootfs tarball> <path to android system.img>
 
 This will do the following:
 


### PR DESCRIPTION
The default script fails for a lot of people (it never worked on HTC 10 for example). I am a bit tired of sending the link to JBB's script, so I thought that it would be nice to mention in the docs.