### PR TITLE
Update the common errors with setup script changes

### DIFF
--- a/porting/common-system-build-errors.rst
+++ b/porting/common-system-build-errors.rst
@@ -10,7 +10,7 @@ signapk.jar missing
 
     error: 'out/host/linux-x86/framework/signapk.jar', needed by 'out/target/product/kenzo/obj/APPS/TimeService_intermediates/package.apk', missing and no rule to make it
 
-Remove all APKs and Java libraries from the Makefiles in ``vendor/[manufacturer]/[device]`` and ``device/[manufacturer]/[device]``. Simply commenting them out is enough, but you can remove them entirely. An example of these changes can be found at `remove APKs on Lyudmila17/android_device_motorola_athene`_.
+All APKs and Java libraries should be removed from the Makefiles in ``vendor/[manufacturer]/[device]`` and ``device/[manufacturer]/[device]``. The setup script will take care of this for you normally. In case you want to do it manually, simply commenting them out is enough, but you can remove them entirely. An example of these changes can be found at `remove APKs on Lyudmila17/android_device_motorola_athene`_.
 
 Also check the vendor folders of your dependencies.
 


### PR DESCRIPTION
The setup script in halium-devices repo now takes care of the APK/JAR issue. Updated documentation to correctly reflect this.

Signed-off-by: Herman van Hazendonk <github.com@herrie.org>