### PR TITLE
get-sources.rst: Speed up the repo sync

### DIFF
--- a/porting/get-sources.rst
+++ b/porting/get-sources.rst
@@ -16,11 +16,11 @@ This directory will be called BUILDDIR in the remaining part of the guide, when 
 
 If the target device has Android 7.1 or LineageOS 14.1 support, it's recommended to select ``halium-7.1``::
 
-   repo init -u https://github.com/Halium/android -b halium-7.1
+   repo init -u https://github.com/Halium/android -b halium-7.1 --depth=1
 
 If your device does not have Android 7.1 or LineageOS 14.1 support but has support for Android 5.1 or CyanogenMod 12.1, select ``halium-5.1``\ ::
 
-   repo init -u https://github.com/Halium/android -b halium-5.1
+   repo init -u https://github.com/Halium/android -b halium-5.1 --depth=1
 
 ``halium-7.1`` is based on LineageOS 14.1
 
@@ -28,7 +28,7 @@ If your device does not have Android 7.1 or LineageOS 14.1 support but has suppo
 
 Now that you have initialized the Halium tree, you can sync all repositories included in it. This will probably take a while as it downloads several GBs::
 
-   repo sync -c
+   repo sync -c -j 16
 
 
 Adding your device-specific source

--- a/porting/get-sources.rst
+++ b/porting/get-sources.rst
@@ -26,10 +26,13 @@ If your device does not have Android 7.1 or LineageOS 14.1 support but has suppo
 
 ``halium-5.1`` is based on CyanogenMod 12.1
 
-Now that you have initialized the Halium tree, you can sync all repositories included in it. This will probably take a while as it downloads several GBs::
+Now that you have initialized the Halium tree (a shallow copy due to --depth=1), you can sync all repositories included in it. This will probably take a while as it downloads several GBs::
 
    repo sync -c -j 16
 
+In case you want to get the full repo history at some point in the future because you want to patch, contribute, etc. You can execute the following command from the repository directory ::
+
+   git fetch --unshallow
 
 Adding your device-specific source
 ----------------------------------


### PR DESCRIPTION
By adding --depth=1 and -j 16 the repo sync will be a lot smaller and quicker and in general fit for our purpose.

Signed-off-by: Herman van Hazendonk <github.com@herrie.org>