### PR TITLE
debug: wifi: some Qualcomm wifi error cases

### DIFF
--- a/porting/debug-build/wifi.rst
+++ b/porting/debug-build/wifi.rst
@@ -30,7 +30,7 @@ Try to load the ``wlan`` kernel module first::
 
 If ``insmod`` fails with ``Required key is not found``, you could temporarily disable all the ``CONFIG_MODULE_SIG**`` options in your ``defconfig`` and then re-build ``hybris-boot`` (or ``halium-boot``) and ``system.img``. **Beware: this disables kernel module signatures (a security feature) — consider fixing it later.**
 
-If ``insmod`` fails with ``Invalid module format``, then you need to ensure that you build your ``hybris-boot`` (or ``halium-boot``) and ``system.img`` with the same kernel configuration (e.g. perhaps you forgot to re-install ``system.img`` after disabling kernel module signatures above).
+If ``insmod`` fails with ``Invalid module format``, then you need to ensure that you build your ``hybris-boot`` (or ``halium-boot``) and ``system.img`` with the same kernel configuration (e.g. perhaps you forgot to re-install ``system.img`` after disabling kernel module signatures above, it contains kernel modules).
 
 Broadcom bcmdhd
 ^^^^^^^^^^^^^^^

--- a/porting/debug-build/wifi.rst
+++ b/porting/debug-build/wifi.rst
@@ -13,6 +13,25 @@ Wifi is fairly easy to get going on most Qualcomm devices. The following should 
    echo 1 > /dev/wcnss_wlan
    echo sta > /sys/module/wlan/parameters/fwpath
 
+Errors
+~~~~~~
+
+What to do if the first command line fails with ``/dev/wcnss_wlan: Bad address``
+********************************************************************************
+
+This is not an error condition; don't get put off — try the second command.
+
+What to try if ``/sys/module/wlan`` is missing (not found)
+**********************************************************
+
+Try to load the ``wlan`` kernel module first::
+
+    insmod /system/lib/modules/wlan.ko
+
+If ``insmod`` fails with ``Required key is not found``, you could temporarily disable all the ``CONFIG_MODULE_SIG**`` options in your ``defconfig`` and then re-build ``hybris-boot`` and ``system.img``. **Beware: this disables kernel module signatures (a security feature) — consider fixing it later.**
+
+If ``insmod`` fails with ``Invalid module format``, then you need to ensure that you build your ``hybris-boot`` and ``system.img`` with the same kernel configuration (e.g. perhaps you forgot to re-install ``system.img`` after disabling kernel module signatures above).
+
 Broadcom bcmdhd
 ^^^^^^^^^^^^^^^
 

--- a/porting/debug-build/wifi.rst
+++ b/porting/debug-build/wifi.rst
@@ -16,21 +16,21 @@ Wifi is fairly easy to get going on most Qualcomm devices. The following should 
 Errors
 ~~~~~~
 
-What to do if the first command line fails with ``/dev/wcnss_wlan: Bad address``
-********************************************************************************
+If the first command line fails with ``/dev/wcnss_wlan: Bad address``
+*********************************************************************
 
 This is not an error condition; don't get put off — try the second command.
 
-What to try if ``/sys/module/wlan`` is missing (not found)
-**********************************************************
+If ``/sys/module/wlan`` is missing (not found)
+**********************************************
 
 Try to load the ``wlan`` kernel module first::
 
     insmod /system/lib/modules/wlan.ko
 
-If ``insmod`` fails with ``Required key is not found``, you could temporarily disable all the ``CONFIG_MODULE_SIG**`` options in your ``defconfig`` and then re-build ``hybris-boot`` and ``system.img``. **Beware: this disables kernel module signatures (a security feature) — consider fixing it later.**
+If ``insmod`` fails with ``Required key is not found``, you could temporarily disable all the ``CONFIG_MODULE_SIG**`` options in your ``defconfig`` and then re-build ``hybris-boot`` (or ``halium-boot``) and ``system.img``. **Beware: this disables kernel module signatures (a security feature) — consider fixing it later.**
 
-If ``insmod`` fails with ``Invalid module format``, then you need to ensure that you build your ``hybris-boot`` and ``system.img`` with the same kernel configuration (e.g. perhaps you forgot to re-install ``system.img`` after disabling kernel module signatures above).
+If ``insmod`` fails with ``Invalid module format``, then you need to ensure that you build your ``hybris-boot`` (or ``halium-boot``) and ``system.img`` with the same kernel configuration (e.g. perhaps you forgot to re-install ``system.img`` after disabling kernel module signatures above).
 
 Broadcom bcmdhd
 ^^^^^^^^^^^^^^^


### PR DESCRIPTION
This commit documents the confusing `Bad address` non-error during Wifi bringup on Qualcomm devices.

It also documents a specific issue that I ran into -- though I haven't heard anyone else having this problem.

I'm not sure how I feel about suggesting to disable a kernel security feature, but until I figure out how to solve the underlying issue, I'd rather have some method to get Wifi working, and I think it's important to build up the corpus of encountered issues in case anybody else should run into them.