### PR TITLE
Docs fixes found in UBports Live Porting

### DIFF
--- a/porting/common-kernel-build-errors.rst
+++ b/porting/common-kernel-build-errors.rst
@@ -8,7 +8,7 @@ Implicit declaration of 'kvfree'
 
 If you receive something similar to the following error::
 
-   ../../../../../../kernel/[...]/[...]/security/apparmor/apparmorfs.c: In function 'aa_simple_write_to_buffer': 
+   ../../../../../../kernel/[...]/[...]/security/apparmor/apparmorfs.c: In function 'aa_simple_write_to_buffer':
    ../../../../../../kernel/[...]/[...]/security/apparmor/apparmorfs.c:110:3: error: implicit declaration of function 'kvfree' [-Werror=implicit-function-declaration]
    kvfree(data);
 
@@ -18,7 +18,7 @@ Apply the patch `nick kvfree() from apparmor`_.
 .. _nick kvfree() from apparmor: https://github.com/ubports/android_kernel_moto_shamu/commit/83f949a8de673fe45499d1741da8654831a5afae
 
 
-'kuid_t' (sdcardfs, cgroup) error 
+'kuid_t' (sdcardfs, cgroup) error
 ---------------------------------
 
 Example of the error::
@@ -28,7 +28,7 @@ Example of the error::
 
    ../../../../../../kernel/lenovo/msm8916/kernel/cgroup.c:2139:18: error: invalid operands to binary != (have 'kuid_t' and 'kuid_t')
        cred->euid != tcred->suid)
-       
+
 Set ``CONFIG_USER_NS`` to ``n`` in your defconfig.
 
 Firmware class error
@@ -39,7 +39,7 @@ Example of the error::
    ../../../../../../kernel/lenovo/msm8916/drivers/base/firmware_class.c: In function '_request_firmware':
    ../../../../../../kernel/lenovo/msm8916/drivers/base/firmware_class.c:1226:38: warning: passing argument 2 of 'fw_load_from_user_helper' from incompatible pointer type
    error, forbidden warning: firmware_class.c:1226
-   
+
 Set ``CONFIG_FW_LOADER_USER_HELPER`` to ``y`` in your defconfig.
 
 ECRYPTFS error

--- a/porting/common-kernel-build-errors.rst
+++ b/porting/common-kernel-build-errors.rst
@@ -19,7 +19,7 @@ Apply the patch `nick kvfree() from apparmor`_.
 
 
 'kuid_t' (sdcardfs, cgroup) error 
-----------------------------------
+---------------------------------
 
 Example of the error::
 
@@ -32,7 +32,7 @@ Example of the error::
 Set ``CONFIG_USER_NS`` to ``n`` in your defconfig.
 
 Firmware class error
-----------------------
+--------------------
 
 Example of the error::
 
@@ -43,7 +43,7 @@ Example of the error::
 Set ``CONFIG_FW_LOADER_USER_HELPER`` to ``y`` in your defconfig.
 
 ECRYPTFS error
-----------------------
+--------------
 
 Example of the error::
 

--- a/porting/common-kernel-build-errors.rst
+++ b/porting/common-kernel-build-errors.rst
@@ -14,10 +14,6 @@ If you receive something similar to the following error::
 
 Apply the patch `nick kvfree() from apparmor`_.
 
-
-.. _nick kvfree() from apparmor: https://github.com/ubports/android_kernel_moto_shamu/commit/83f949a8de673fe45499d1741da8654831a5afae
-
-
 'kuid_t' (sdcardfs, cgroup) error
 ---------------------------------
 
@@ -51,6 +47,41 @@ Example of the error::
    ../../../../../../kernel/lenovo/msm8916/fs/ecryptfs/file.c:130:16: error: assignment of read-only member 'actor'
   buf.ctx.actor = ecryptfs_filldir;
 
-Apply `this patch from bullhead`_.
+Apply `'patch ecryptfs to fix a build error' from bullhead`_.
 
-.. _this patch from bullhead: https://github.com/usb-bullhead-ubuntu-touch/kernel_msm/commit/b0403f0ee02e6582017cdb45b4c0c72b00cc72eb
+'Undefined reference to pidns_operations' on Linux 3.4
+------------------------------------------------------
+
+The implementation of PID Namespacing was incomplete in the Android kernel 3.4, causing the following error::
+
+   fs/built-in.o:namespaces.c:ns_entries: error: undefined reference to 'pidns_operations'
+
+To fix this issue, apply the patch `Finish implementation of PID namespace`_
+
+'struct perf_cpu_context' has no member named 'unique_pmu'
+----------------------------------------------------------
+
+This is caused by an incomplete merge of a few changes in some 3.4 kernels::
+
+   /../../../../kernel/fairphone/msm8974/kernel/events/core.c: In function 'perf_cgroup_switch':
+   /../../../../kernel/fairphone/msm8974/kernel/events/core.c:379:13: error: 'struct perf_cpu_context' has no member named 'unique_pmu'
+   if (cpuctx->unique_pmu != pmu)
+
+Reverting `perf: Fix perf_cgroup_switch for sw-events`_ should fix the problem.
+
+'PROC_PID_INIT_INO' undeclared here (not in a function)
+-------------------------------------------------------
+
+Somehow, the implementation of the ``/proc`` filesystem is incomplete in some 3.4 kernels::
+
+   /../../../../kernel/fairphone/msm8974/kernel/pid.c:81:15: error: 'PROC_PID_INIT_INO' undeclared here (not in a function)
+     .proc_inum = PROC_PID_INIT_INO,
+
+Add the following line after all of the other ``#include`` lines in the file::
+
+   #include <linux/proc_fs.h>
+
+.. _'patch ecryptfs to fix a build error' from bullhead: https://github.com/usb-bullhead-ubuntu-touch/kernel_msm/commit/b0403f0ee02e6582017cdb45b4c0c72b00cc72eb
+.. _nick kvfree() from apparmor: https://github.com/ubports/android_kernel_moto_shamu/commit/83f949a8de673fe45499d1741da8654831a5afae
+.. _Finish implementation of PID namespace: https://github.com/Halium/android_kernel_lge_hammerhead/commit/bd221854de33b75db7a7fa01cb34274b62a7cbf8
+.. _perf\: Fix perf_cgroup_switch for sw-events: https://github.com/LineageOS/android_kernel_fairphone_msm8974/commit/fed4b99c5eb99ab792f223cefef67d940bbe8796

--- a/porting/common-system-build-errors.rst
+++ b/porting/common-system-build-errors.rst
@@ -41,7 +41,7 @@ Flex locale error
    flex-2.5.39: loadlocale.c:130: _nl_intern_locale_data: Assertion `cnt < (sizeof (_nl_value_type_LC_TIME) / sizeof (_nl_value_type_LC_TIME[0]))' failed.
    Aborted (core dumped)
 
-This to be a problem with locales and the prebuilt ``flex``. You can avoid this by using the flex installed on your host::
+This seems to be a problem with locales and the prebuilt ``flex``. You can avoid this by using the flex installed on your host::
 
     export USE_HOST_LEX=yes
     make systemimage

--- a/porting/common-system-build-errors.rst
+++ b/porting/common-system-build-errors.rst
@@ -41,8 +41,7 @@ Flex locale error
    flex-2.5.39: loadlocale.c:130: _nl_intern_locale_data: Assertion `cnt < (sizeof (_nl_value_type_LC_TIME) / sizeof (_nl_value_type_LC_TIME[0]))' failed.
    Aborted (core dumped)
 
+This to be a problem with locales and the prebuilt ``flex``. You can avoid this by using the flex installed on your host::
 
-
-Seems to be a problem with locales and the prebuilt `flex`. You can avoid this by using the "C" locale while building::
-
-   LANG=C make systemimage
+    export USE_HOST_LEX=yes
+    make systemimage

--- a/porting/first-steps.rst
+++ b/porting/first-steps.rst
@@ -65,15 +65,13 @@ Install the required dependencies::
 Arch
 ^^^^
 
-If you have a pure ``amd64`` running you need to add ``[multilib]`` repository to your ``/etc/pacman.conf`` . This will allow you to install and run ``i686`` packages. Please refer to `<https://wiki.archlinux.org/index.php/multilib>`_
-Assuming you have already installed ``base-devel`` group; if not, then please install ``base-devel``.
+If you have an ``amd64`` installation of Arch, you need to add the ``[multilib]`` repository to your ``/etc/pacman.conf`` . This will allow you to install and run ``i686`` packages. Please refer to `'Official Repositories/multilib' on the Arch Wiki <https://wiki.archlinux.org/index.php/multilib>`_.
+
+Install the ``base-devel`` package if you have not already.
 
 Install the required dependencies from AUR::
 
    git clone https://aur.archlinux.org/halium-devel.git && cd halium-devel && makepkg -i
 
 .. Note::
-    Arch uses python3 as default version for Python, which may cause some errors while building. Using a Python virtualenv2 is highly recommended. Please refer to `<https://wiki.archlinux.org/index.php/Python/Virtual_environment>`_ for instructions on setting the Virtual Environment.
-
-.. todo::
-    Add information for installing packages on other distros
+    Arch uses Python 3 as its default ``python``, which may cause some errors while building. Using a Python 2 virtualenv is highly recommended. Please refer to `'Python/Virtual environment' on the Arch Wiki <https://wiki.archlinux.org/index.php/Python/Virtual_environment>`_ for instructions on setting up a Virtual Environment.

--- a/porting/first-steps.rst
+++ b/porting/first-steps.rst
@@ -49,6 +49,10 @@ If you are on the ``amd64`` architecture (commonly referred to as 64 bit), enabl
 
    sudo dpkg --add-architecture i386
 
+Update your package lists to take advantage of the new architecture::
+
+    sudo apt update
+
 Install the required dependencies::
 
    sudo apt install git gnupg flex bison gperf build-essential \


### PR DESCRIPTION
During the [UBports live porting session](https://www.youtube.com/watch?v=nShXVDXM50A), we found some places where the documentation needed some cleaning. This PR

* Lints the kernel build errors file
* Adds the build errors we hit while building for the Fairphone 2
* Fixes some small errors in the "First steps" file