### PR TITLE
Add LC_ALL=C step for Ubuntu 18.04

### DIFF
--- a/porting/first-steps.rst
+++ b/porting/first-steps.rst
@@ -49,6 +49,12 @@ If you are on the ``amd64`` architecture (commonly referred to as 64 bit), enabl
 
    sudo dpkg --add-architecture i386
 
+Ubuntu 18.04 needs a flag to be set in the ~/.bashrc file to enable the build to complete successfully. Run this command to set the flag::
+
+   export LC_ALL=C
+
+and add it to your ~/.bashrc file so it is automatically applied to every new shell instance
+
 Install the required dependencies::
 
    sudo apt install git gnupg flex bison gperf build-essential \


### PR DESCRIPTION
We need to set LC_ALL=C in order to make sure that build succeeds on 18.04. As per steps from LineageOS: https://review.lineageos.org/c/LineageOS/lineage_wiki/+/219048/7/_includes/templates/device_build.md

Signed-off-by: Herman van Hazendonk <github.com@herrie.org>