### PR TITLE
common-kernel-build-errors.rst: Add systemd 233+ fix for 3.4 kernels

### DIFF
--- a/porting/build-sources.rst
+++ b/porting/build-sources.rst
@@ -66,6 +66,11 @@ If you don't know the path to your kernel config run ``grep "TARGET_KERNEL_CONFI
 .. todo::
     Mention that the config parameters CONFIG_IKCONFIG and CONFIG_IKCONFIG_PROC need to be set to y, otherwise Halium wont boot (or add them to the check script
 
+As of systemd 233 the 3.4 kernel needs to have a patch in order to boot (tmpmnt not being created)
+--------------------------------------------------------------------------------------------------
+
+Due to changes introduced in systemd 233, specifically https://github.com/systemd/systemd-stable/commit/e187369587b1c6a5f65a12e7ec0bf7844905d014#diff-091b5e8286ba9db94f3958b92eb3653a is causing issues in many 3.4 kernels due to fstat not returning the correct value. A simple one line patch to the kernel will address this. See https://github.com/ubports/android_kernel_google_msm/pull/5/commits/1ad88b041787d8ce8407a021271ef1031e95cba6 
+
 Include your device in fixup-mountpoints
 ----------------------------------------
 

--- a/porting/common-kernel-build-errors.rst
+++ b/porting/common-kernel-build-errors.rst
@@ -77,7 +77,7 @@ Somehow, the implementation of the ``/proc`` filesystem is incomplete in some 3.
    /../../../../kernel/fairphone/msm8974/kernel/pid.c:81:15: error: 'PROC_PID_INIT_INO' undeclared here (not in a function)
      .proc_inum = PROC_PID_INIT_INO,
 
-Add the following line after all of the other ``#include`` lines in the file::
+Add the following line after all of the other ``#include`` lines in the file kernel/user_namespace.c similar to https://github.com/Halium/android_kernel_lge_hammerhead/commit/5754614eb43dea44a99e54898e3b83d4d96d8b83 ::
 
    #include <linux/proc_fs.h>
 


### PR DESCRIPTION
Signed-off-by: Herman van Hazendonk <github.com@herrie.org>