### PR TITLE
Add libncurses5 and rsync to the list of dependencies on Debian

### DIFF
--- a/porting/first-steps.rst
+++ b/porting/first-steps.rst
@@ -68,7 +68,7 @@ Install the required dependencies::
      libx11-dev:i386 libreadline6-dev:i386 libgl1-mesa-glx:i386 \
      libgl1-mesa-dev g++-multilib mingw-w64-i686-dev tofrodos \
      python-markdown libxml2-utils xsltproc zlib1g-dev:i386 schedtool \
-     repo liblz4-tool bc lzop imagemagick
+     repo liblz4-tool bc lzop imagemagick libncurses5
 
 Arch
 ^^^^

--- a/porting/first-steps.rst
+++ b/porting/first-steps.rst
@@ -68,7 +68,7 @@ Install the required dependencies::
      libx11-dev:i386 libreadline6-dev:i386 libgl1-mesa-glx:i386 \
      libgl1-mesa-dev g++-multilib mingw-w64-i686-dev tofrodos \
      python-markdown libxml2-utils xsltproc zlib1g-dev:i386 schedtool \
-     repo liblz4-tool bc lzop imagemagick libncurses5
+     repo liblz4-tool bc lzop imagemagick libncurses5 rsync
 
 Arch
 ^^^^


### PR DESCRIPTION
mka mkbootimg fails without libncurses.so.5 and mka systemimage fails without rsync