### PR TITLE
Add LC_ALL="C.UTF-8" for mka systemimage

### DIFF
--- a/porting/build-sources.rst
+++ b/porting/build-sources.rst
@@ -112,7 +112,7 @@ Halium will use the mkbootimg tool for creating the boot image. In most cases it
 To build the ``system.img`` and ``hybris-boot.img`` - required for Halium - use the following commands::
 
    mka hybris-boot
-   mka systemimage
+   LC_ALL="C.UTF-8" mka systemimage
 
 .. note::
 

--- a/porting/build-sources.rst
+++ b/porting/build-sources.rst
@@ -111,8 +111,9 @@ Halium will use the mkbootimg tool for creating the boot image. In most cases it
 
 To build the ``system.img`` and ``hybris-boot.img`` - required for Halium - use the following commands::
 
+   export USE_HOST_LEX=yes
    mka hybris-boot
-   LC_ALL="C.UTF-8" mka systemimage
+   mka systemimage
 
 .. note::
 


### PR DESCRIPTION
In my locale, `fr_FR.UTF-8`, `mka systemimage` fails with this error:

    Assertion `cnt < (sizeof (_nl_value_type_LC_TIME) / sizeof (_nl_value_type_LC_TIME[0]))' failed.

This assertion error does not show up when prefixing `mka systemimage` by `LC_ALL="C.UTF-8"`.