### PR TITLE
Update first-steps.rst

### DIFF
--- a/porting/first-steps.rst
+++ b/porting/first-steps.rst
@@ -86,7 +86,7 @@ Install the required dependencies::
       zip bzr curl libc6-dev libncurses5-dev:i386 x11proto-core-dev \
       libx11-dev:i386 libreadline6-dev:i386 libgl1-mesa-glx:i386 \
       libgl1-mesa-dev g++-multilib mingw-w64-i686-dev tofrodos \
-      python-markdown libxml2-utils xsltproc zlib1g-dev:i386 schedtool \
+      python3-markdown libxml2-utils xsltproc zlib1g-dev:i386 schedtool \
       liblz4-tool bc lzop imagemagick libncurses5 rsync \
       python-is-python3
 

--- a/porting/first-steps.rst
+++ b/porting/first-steps.rst
@@ -66,7 +66,7 @@ Install the required dependencies::
       zip bzr curl libc6-dev libncurses5-dev:i386 x11proto-core-dev \
       libx11-dev:i386 libreadline6-dev:i386 libgl1-mesa-glx:i386 \
       libgl1-mesa-dev g++-multilib mingw-w64-i686-dev tofrodos \
-      python-markdown libxml2-utils xsltproc zlib1g-dev:i386 schedtool \
+      python3-markdown libxml2-utils xsltproc zlib1g-dev:i386 schedtool \
       repo liblz4-tool bc lzop imagemagick libncurses5 rsync
 
 Ubuntu (20.04 or newer)


### PR DESCRIPTION
Package *python-markdown* is obsoleted,but is referred to by another package, *python3-markdown*