### PR TITLE
Changed compilation dependencies on debian.

### DIFF
--- a/porting/first-steps.rst
+++ b/porting/first-steps.rst
@@ -49,7 +49,7 @@ Set up your build device
 
 Now you will need to install packages on the computer you wish to build Halium with. Make sure to have Python 3.6 or higher installed.
 
-Debian (Stretch or newer) / Ubuntu (16.04 or 18.04)
+Debian (Buster or Bullseye) / Ubuntu (16.04 or 18.04)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 If you are on the ``amd64`` architecture (commonly referred to as 64 bit), enable the usage of the ``i386`` architecture::
@@ -67,6 +67,26 @@ Install the required dependencies::
       libx11-dev:i386 libreadline6-dev:i386 libgl1-mesa-glx:i386 \
       libgl1-mesa-dev g++-multilib mingw-w64-i686-dev tofrodos \
       python-markdown libxml2-utils xsltproc zlib1g-dev:i386 schedtool \
+      repo liblz4-tool bc lzop imagemagick libncurses5 rsync
+
+Debian (Bookworm or newer) 
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+If you are on the ``amd64`` architecture (commonly referred to as 64 bit), enable the usage of the ``i386`` architecture::
+
+    sudo dpkg --add-architecture i386
+
+Update your package lists to take advantage of the new architecture::
+
+    sudo apt update
+
+Install the required dependencies::
+
+    sudo apt install git gnupg flex bison gperf build-essential \
+      zip bzr curl libc6-dev libncurses5-dev:i386 x11proto-core-dev \
+      libx11-dev:i386 libreadline6-dev:i386 libgl1-mesa-glx:i386 \
+      libgl1-mesa-dev g++-multilib mingw-w64-i686-dev tofrodos \
+      python3-markdown libxml2-utils xsltproc zlib1g-dev:i386 schedtool \
       repo liblz4-tool bc lzop imagemagick libncurses5 rsync
 
 Ubuntu (20.04 or newer)


### PR DESCRIPTION
When I install the compiled dependencies this output comes out
```Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
Package python-markdown is not available, but is referred to by another package.
This may mean that the package is missing, has been obsoleted, or
is only available from another source
However the following packages replace it:
  python3-markdown

E: Package 'python-markdown' has no installation candidate
```
 My distro version is Debian GNU/Linux 12 (bookworm) x86_64